### PR TITLE
Fix to use slice when doing slice benchmark instead of using array

### DIFF
--- a/defer_test.go
+++ b/defer_test.go
@@ -9,8 +9,7 @@ func BenchmarkDefer(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		for i := 0; i < BenchMarkSize; i++ {
 			func() {
-				var item int
-				item = m[i]
+				var item = m[i]
 				defer checkItem(b, i, item)
 			}()
 		}
@@ -22,8 +21,7 @@ func BenchmarkDeferNo(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		for i := 0; i < BenchMarkSize; i++ {
 			func() {
-				var item int
-				item = m[i]
+				var item = m[i]
 				checkItem(b, i, item)
 			}()
 		}

--- a/goroutine_test.go
+++ b/goroutine_test.go
@@ -49,12 +49,9 @@ func newGrp(N int64, valChanCnt int64, loopCnt int64) (r *grp) {
 	return r
 }
 func (g *grp) loop() {
-	for {
-		select {
-		case n := <-g.valsC:
-			g.vals[n] = n % g.cnt
-			g.wg.Done()
-		}
+	for n := range g.valsC {
+		g.vals[n] = n % g.cnt
+		g.wg.Done()
 	}
 }
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -10,8 +10,8 @@ const (
 	BenchMarkSizeLong = BenchMarkSize << 5
 )
 
-func generateIntSlice(b *testing.B) [BenchMarkSize]int {
-	var m [BenchMarkSize]int
+func generateIntSlice(b *testing.B) []int {
+	var m = make([]int, BenchMarkSize)
 	for i := 0; i < BenchMarkSize; i++ {
 		m[i] = i
 	}

--- a/parameter_test.go
+++ b/parameter_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 )
 
-func getSliceItem(index int, m [BenchMarkSize]int) int {
+func getSliceItem(index int, m []int) int {
 	return m[index]
 }
 
-func getSlicePointerItem(index int, m *[BenchMarkSize]int) int {
-	return m[index]
+func getSlicePointerItem(index int, m *[]int) int {
+	return (*m)[index]
 }
 
 func BenchmarkParameterSlicePassedByValue(b *testing.B) {


### PR DESCRIPTION
how to test

```console
go test -bench=.
```

The measurements in README.md will be updated in another PR after it has been approved.